### PR TITLE
Use provided systemctl is-active command in status_wireguard

### DIFF
--- a/wireguard-manager.sh
+++ b/wireguard-manager.sh
@@ -9,7 +9,7 @@ rofi -dmenu -password -no-fixed-num-lines -p "Sudo password : " -theme ~/.confi
 }
 
 function status_wireguard() {
-  systemctl status $SERVICE_NAME | grep "Active: active" -q
+  systemctl is-active $SERVICE_NAME >/dev/null 2>&1
   return $?
 }
 


### PR DESCRIPTION
> Notice: I'm just a passer-by that noticed some areas that could be improved -- I only ran the single-line modification I made **independently** from the script, i.e. in my shell -- I don't have the necessary software to run the whole script. 

> Please test this PR before you accept it.

`status_wireguard()` previously asked `systemctl` for the `$SERVICE_NAME` variable status, and used a silent `grep` to find out whether or not the service was active.

This commit relies on `systemctl` only, whilst preserving the behavior of silencing output from stderr, and stdout, by redirecting both streams to `/dev/null`.