### PR TITLE
Update README.md with changes to the waybar module

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ Clone the repository in `~/.config/waybar/wireguard-manager`, then add this to
 See [Waybar's wiki](https://github.com/Alexays/Waybar/wiki/Module:-Custom) for
 more information on how to customize this.
 
+### Toggling WireGuard "manually"
+
+If you intend on turning your Wireguard tunnel on and off through other means other than clicking on this waybar module, it can be useful to set the module itself in a different fashion:
+
+```json
+"custom/wireguard-manager": {
+    "interval": 3,
+    "return-type": "json",
+    "format-icons": {
+        "connected": "<span color=\"#50fa7b\">VPN: 🔒</span>",
+        "disconnected": "<span color=\"#ff5555\">VPN: 🔓</span>"
+    },
+    "on-click": "exec ~/.config/waybar/wireguard-manager/wireguard-manager.sh -t",
+    "exec": "exec ~/.config/waybar/wireguard-manager/wireguard-manager.sh -s",
+    "format": "{icon}"
+}
+```
+
+This is because the version of the module presented first updates itself only when clicked on, to avoid constant polling of the status of the systemd service for Wireguard. If you do use other means to set your tunnel up or down (such as `sudo systemctl stop wg-quick@wg0.service`), it is recommended to use this other version of the module, as it polls the current status of the systemd service every 3 seconds, updating the status of the module without requiring the user to click on it.
+
 ## Usage
 
 With the given configuration, the status of the connection will be updated every

--- a/README.md
+++ b/README.md
@@ -35,15 +35,16 @@ Clone the repository in `~/.config/waybar/wireguard-manager`, then add this to
 
 ```json
 "custom/wireguard-manager": {
-    "interval": 3,
-    "return-type": "json",
+    "exec": "exec ~/.config/waybar/wireguard-manager/wireguard-manager.sh -s",
+    "format": "{icon}",
     "format-icons": {
         "connected": "<span color=\"#50fa7b\">VPN: 🔒</span>",
-        "disconnected": "<span color=\"#ff5555\">VPN: 🔓</span>"
+        "disconnected": "<span color=\"#ff5555\">VPN: 🔓</span>",
     },
-    "on-click": "exec ~/.config/waybar/wireguard-manager/wireguard-manager.sh -t",
-    "exec": "exec ~/.config/waybar/wireguard-manager/wireguard-manager.sh -s",
-    "format": "{icon}"
+    "interval": "once",
+    "on-click": "~/.config/waybar/wireguard-manager/wireguard-manager.sh -t && pkill -SIGRTMIN+1 waybar",
+    "return-type": "json",
+    "signal": 1,
 }
 ```
 


### PR DESCRIPTION
The original module uses an interval of 3 (seconds) to update the status of the WireGuard tunnel as up or down (well, the systemd service, anyway).

With my changes to the module, this constant polling is made unnecessary, as it updates everytime the script is run successfully (i.e. the systemd service for wg0 is toggled successfully). However, this is useful only if the interface used to toggle the WireGuard tunnel is the module itself; if someone were to "manually" toggle WireGuard on a terminal emulator, the module will not update itself until clicked on.

My use case doesn't require any other interface to put wg0 up or down other than the module itself, so I chose to contribute here in case anyone else thinks this might be a good idea.